### PR TITLE
BUG: Repeated log calls

### DIFF
--- a/log.py
+++ b/log.py
@@ -36,25 +36,25 @@ def setup_logging(log_file='log.txt', resume=False, dummy=False):
     """
     if dummy:
         logging.getLogger('dummy')
+        return
+    if os.path.isfile(log_file) and resume:
+        file_mode = 'a'
     else:
-        if os.path.isfile(log_file) and resume:
-            file_mode = 'a'
-        else:
-            file_mode = 'w'
+        file_mode = 'w'
 
-        root_logger = logging.getLogger()
-        if root_logger.handlers:
-            root_logger.removeHandler(root_logger.handlers[0])
-        logging.basicConfig(level=logging.DEBUG,
-                            format="%(asctime)s - %(levelname)s - %(message)s",
-                            datefmt="%Y-%m-%d %H:%M:%S",
-                            filename=log_file,
-                            filemode=file_mode)
-        console = logging.StreamHandler()
-        console.setLevel(logging.INFO)
-        formatter = logging.Formatter('%(message)s')
-        console.setFormatter(formatter)
-        logging.getLogger('').addHandler(console)
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        root_logger.removeHandler(root_logger.handlers[0])
+    logging.basicConfig(level=logging.DEBUG,
+                        format="%(asctime)s - %(levelname)s - %(message)s",
+                        datefmt="%Y-%m-%d %H:%M:%S",
+                        filename=log_file,
+                        filemode=file_mode)
+    console = logging.StreamHandler()
+    console.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(message)s')
+    console.setFormatter(formatter)
+    logging.getLogger('').addHandler(console)
 
 
 def plot_figure(data, x, y, title=None, xlabel=None, ylabel=None, legend=None,

--- a/log.py
+++ b/log.py
@@ -37,10 +37,8 @@ def setup_logging(log_file='log.txt', resume=False, dummy=False):
     if dummy:
         logging.getLogger('dummy')
         return
-    if os.path.isfile(log_file) and resume:
-        file_mode = 'a'
-    else:
-        file_mode = 'w'
+
+    file_mode = 'a' if os.path.isfile(log_file) and resume else 'w'
 
     root_logger = logging.getLogger()
     if root_logger.handlers:

--- a/log.py
+++ b/log.py
@@ -41,18 +41,22 @@ def setup_logging(log_file='log.txt', resume=False, dummy=False):
     file_mode = 'a' if os.path.isfile(log_file) and resume else 'w'
 
     root_logger = logging.getLogger()
-    if root_logger.handlers:
-        root_logger.removeHandler(root_logger.handlers[0])
     logging.basicConfig(level=logging.DEBUG,
                         format="%(asctime)s - %(levelname)s - %(message)s",
-                        datefmt="%Y-%m-%d %H:%M:%S",
-                        filename=log_file,
-                        filemode=file_mode)
+                        datefmt="%Y-%m-%d %H:%M:%S")
+    # Remove all existing handlers (can't use the `force` option with
+    # python < 3.8)
+    for hdlr in root_logger.handlers[:]:
+        root_logger.removeHandler(hdlr)
+    # Add the handlers we want to use
+    fileout = logging.FileHandler(log_file, mode=file_mode)
+    fileout.setLevel(logging.DEBUG)
+    fileout.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    logging.getLogger().addHandler(fileout)
     console = logging.StreamHandler()
     console.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(message)s')
-    console.setFormatter(formatter)
-    logging.getLogger('').addHandler(console)
+    console.setFormatter(logging.Formatter('%(message)s'))
+    logging.getLogger().addHandler(console)
 
 
 def plot_figure(data, x, y, title=None, xlabel=None, ylabel=None, legend=None,


### PR DESCRIPTION
Fixes issue when you call `setup_logging()` multiple times.

Previously, the code would remove the first existing handler, which
removed the FileHandler and left the StreamHandler in place. Then
it would add a new StreamHandler. This meant all output was sent to
console twice and not to any file.

Now we remove all existing handlers, and manually add all handlers
we want to have (without relying on `logging.basicConfig()` to
set up the FileHandler). This means that repeated calls to
setup_logging will establish the correct set up - write to console
and one file with the given path.